### PR TITLE
ArangoAnnotationIntrospector

### DIFF
--- a/src/main/java/com/arangodb/jackson/dataformat/velocypack/VelocyJack.java
+++ b/src/main/java/com/arangodb/jackson/dataformat/velocypack/VelocyJack.java
@@ -23,6 +23,7 @@ package com.arangodb.jackson.dataformat.velocypack;
 import com.arangodb.ArangoDBException;
 import com.arangodb.entity.BaseDocument;
 import com.arangodb.entity.BaseEdgeDocument;
+import com.arangodb.jackson.dataformat.velocypack.internal.ArangoAnnotationIntrospector;
 import com.arangodb.jackson.dataformat.velocypack.internal.VPackDeserializers;
 import com.arangodb.jackson.dataformat.velocypack.internal.VPackSerializers;
 import com.arangodb.util.ArangoSerialization;
@@ -79,6 +80,8 @@ public class VelocyJack implements ArangoSerialization {
 		module.addDeserializer(BaseDocument.class, VPackDeserializers.BASE_DOCUMENT);
 		module.addDeserializer(BaseEdgeDocument.class, VPackDeserializers.BASE_EDGE_DOCUMENT);
 		mapper.registerModule(module);
+
+		mapper.setAnnotationIntrospector(new ArangoAnnotationIntrospector());
 
 		return mapper;
 	}

--- a/src/main/java/com/arangodb/jackson/dataformat/velocypack/VelocyJack.java
+++ b/src/main/java/com/arangodb/jackson/dataformat/velocypack/VelocyJack.java
@@ -60,12 +60,21 @@ public class VelocyJack implements ArangoSerialization {
 	private final ObjectMapper jsonMapper;
 	private final VPackParser vpackParser;
 
+	private static final class ArangoModule extends SimpleModule {
+		@Override
+		public void setupModule(SetupContext context) {
+			super.setupModule(context);
+			context.appendAnnotationIntrospector(new ArangoAnnotationIntrospector());
+		}
+	}
+
 	static VPackMapper createDefaultMapper() {
 		final VPackMapper mapper = new VPackMapper();
 		mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 		mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-		final SimpleModule module = new SimpleModule();
+
+		final SimpleModule module = new ArangoModule();
 		module.addSerializer(VPackSlice.class, VPackSerializers.VPACK);
 		module.addSerializer(java.util.Date.class, VPackSerializers.UTIL_DATE);
 		module.addSerializer(java.sql.Date.class, VPackSerializers.SQL_DATE);
@@ -79,10 +88,8 @@ public class VelocyJack implements ArangoSerialization {
 		module.addDeserializer(java.sql.Timestamp.class, VPackDeserializers.SQL_TIMESTAMP);
 		module.addDeserializer(BaseDocument.class, VPackDeserializers.BASE_DOCUMENT);
 		module.addDeserializer(BaseEdgeDocument.class, VPackDeserializers.BASE_EDGE_DOCUMENT);
+
 		mapper.registerModule(module);
-
-		mapper.setAnnotationIntrospector(new ArangoAnnotationIntrospector());
-
 		return mapper;
 	}
 

--- a/src/main/java/com/arangodb/jackson/dataformat/velocypack/VelocyJack.java
+++ b/src/main/java/com/arangodb/jackson/dataformat/velocypack/VelocyJack.java
@@ -64,7 +64,7 @@ public class VelocyJack implements ArangoSerialization {
 		@Override
 		public void setupModule(SetupContext context) {
 			super.setupModule(context);
-			context.appendAnnotationIntrospector(new ArangoAnnotationIntrospector());
+			context.insertAnnotationIntrospector(new ArangoAnnotationIntrospector());
 		}
 	}
 

--- a/src/main/java/com/arangodb/jackson/dataformat/velocypack/internal/ArangoAnnotationIntrospector.java
+++ b/src/main/java/com/arangodb/jackson/dataformat/velocypack/internal/ArangoAnnotationIntrospector.java
@@ -1,0 +1,97 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2016 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.jackson.dataformat.velocypack.internal;
+
+import com.arangodb.entity.DocumentField;
+import com.arangodb.velocypack.annotations.SerializedName;
+import com.fasterxml.jackson.databind.PropertyName;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.AnnotatedParameter;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+
+/**
+ * @author Michele Rastelli
+ */
+public class ArangoAnnotationIntrospector extends JacksonAnnotationIntrospector {
+
+	@Override
+	public PropertyName findNameForSerialization(Annotated a) {
+		PropertyName name = findPropertyName(a);
+		if (name != null) {
+			return name;
+		} else {
+			return super.findNameForSerialization(a);
+		}
+	}
+
+	@Override
+	public PropertyName findNameForDeserialization(Annotated a) {
+		PropertyName name = findPropertyName(a);
+		if (name != null) {
+			return name;
+		} else {
+			return super.findNameForDeserialization(a);
+		}
+	}
+
+	@Override
+	public String findImplicitPropertyName(AnnotatedMember member) {
+		String name = findParameterName(member);
+		if (name != null) {
+			return name;
+		} else {
+			return super.findImplicitPropertyName(member);
+		}
+	}
+
+	private String findParameterName(Annotated a) {
+		if (!(a instanceof AnnotatedParameter)) {
+			return null;
+		}
+
+		final SerializedName serializedName = a.getAnnotation(SerializedName.class);
+		if (serializedName != null) {
+			return serializedName.value();
+		}
+
+		return null;
+	}
+
+	private PropertyName findPropertyName(Annotated a) {
+		if (!(a instanceof AnnotatedMember)) {
+			return null;
+		}
+
+		final DocumentField documentField = a.getAnnotation(DocumentField.class);
+		if (documentField != null) {
+			return PropertyName.construct(documentField.value().getSerializeName());
+		}
+
+		final SerializedName serializedName = a.getAnnotation(SerializedName.class);
+		if (serializedName != null) {
+			return PropertyName.construct(serializedName.value());
+		}
+
+		return null;
+	}
+
+}

--- a/src/test/java/com/arangodb/jackson/dataformat/velocypack/annotations/ArangoAnnotationsTest.java
+++ b/src/test/java/com/arangodb/jackson/dataformat/velocypack/annotations/ArangoAnnotationsTest.java
@@ -1,0 +1,96 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2016 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.jackson.dataformat.velocypack.annotations;
+
+import com.arangodb.entity.DocumentField;
+import com.arangodb.jackson.dataformat.velocypack.VelocyJack;
+import com.arangodb.velocypack.VPackSlice;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Michele Rastelli
+ */
+public class ArangoAnnotationsTest {
+
+	private final VelocyJack mapper = new VelocyJack();
+
+	@Test
+	public void documentField() {
+		DocumentFieldEntity e = new DocumentFieldEntity();
+		e.setId("Id");
+		e.setKey("Key");
+		e.setRev("Rev");
+		e.setFrom("From");
+		e.setTo("To");
+
+		VPackSlice slice = mapper.serialize(e);
+		System.out.println(slice);
+		Map<String, String> deserialized = mapper.deserialize(slice, Object.class);
+		assertThat(deserialized.get(DocumentField.Type.ID.getSerializeName()), is(e.getId()));
+		assertThat(deserialized.get(DocumentField.Type.KEY.getSerializeName()), is(e.getKey()));
+		assertThat(deserialized.get(DocumentField.Type.REV.getSerializeName()), is(e.getRev()));
+		assertThat(deserialized.get(DocumentField.Type.FROM.getSerializeName()), is(e.getFrom()));
+		assertThat(deserialized.get(DocumentField.Type.TO.getSerializeName()), is(e.getTo()));
+		assertThat(deserialized.size(), is(DocumentField.Type.values().length));
+
+		DocumentFieldEntity deserializedEntity = mapper.deserialize(slice, DocumentFieldEntity.class);
+		assertThat(deserializedEntity, is(e));
+	}
+
+	@Test
+	public void serializedName() {
+		SerializedNameEntity e = new SerializedNameEntity();
+		e.setA("A");
+		e.setB("B");
+		e.setC("C");
+
+		VPackSlice slice = mapper.serialize(e);
+		System.out.println(slice);
+		Map<String, String> deserialized = mapper.deserialize(slice, Object.class);
+		assertThat(deserialized.get(SerializedNameEntity.SERIALIZED_NAME_A), is(e.getA()));
+		assertThat(deserialized.get(SerializedNameEntity.SERIALIZED_NAME_B), is(e.getB()));
+		assertThat(deserialized.get(SerializedNameEntity.SERIALIZED_NAME_C), is(e.getC()));
+		assertThat(deserialized.size(), is(3));
+
+		SerializedNameEntity deserializedEntity = mapper.deserialize(slice, SerializedNameEntity.class);
+		assertThat(deserializedEntity, is(e));
+	}
+
+	@Test
+	public void serializedNameParameter() {
+		Map<String, String> e = new HashMap<>();
+		e.put(SerializedNameParameterEntity.SERIALIZED_NAME_A, "A");
+		e.put(SerializedNameParameterEntity.SERIALIZED_NAME_B, "B");
+		e.put(SerializedNameParameterEntity.SERIALIZED_NAME_C, "C");
+
+		VPackSlice slice = mapper.serialize(e);
+		SerializedNameParameterEntity deserializedEntity = mapper
+				.deserialize(slice, SerializedNameParameterEntity.class);
+		assertThat(deserializedEntity, is(new SerializedNameParameterEntity("A", "B", "C")));
+	}
+
+}

--- a/src/test/java/com/arangodb/jackson/dataformat/velocypack/annotations/ArangoAnnotationsTest.java
+++ b/src/test/java/com/arangodb/jackson/dataformat/velocypack/annotations/ArangoAnnotationsTest.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
@@ -91,6 +92,34 @@ public class ArangoAnnotationsTest {
 		SerializedNameParameterEntity deserializedEntity = mapper
 				.deserialize(slice, SerializedNameParameterEntity.class);
 		assertThat(deserializedEntity, is(new SerializedNameParameterEntity("A", "B", "C")));
+	}
+
+	@Test
+	public void expose() {
+		ExposeEntity e = new ExposeEntity();
+		e.setReadWrite("readWrite");
+		e.setReadOnly("readOnly");
+		e.setWriteOnly("writeOnly");
+		e.setIgnored("ignored");
+
+		VPackSlice serializedEntity = mapper.serialize(e);
+		Map<String, String> deserializedEntity = mapper.deserialize(serializedEntity, Object.class);
+		assertThat(deserializedEntity.get("readWrite"), is("readWrite"));
+		assertThat(deserializedEntity.get("readOnly"), is("readOnly"));
+		assertThat(deserializedEntity.size(), is(2));
+
+		Map<String, String> map = new HashMap<>();
+		map.put("readWrite", "readWrite");
+		map.put("readOnly", "readOnly");
+		map.put("writeOnly", "writeOnly");
+		map.put("ignored", "ignored");
+
+		VPackSlice serializedMap = mapper.serialize(map);
+		ExposeEntity deserializedMap = mapper.deserialize(serializedMap, ExposeEntity.class);
+		assertThat(deserializedMap.getIgnored(), is(nullValue()));
+		assertThat(deserializedMap.getReadOnly(), is(nullValue()));
+		assertThat(deserializedMap.getWriteOnly(), is("writeOnly"));
+		assertThat(deserializedMap.getReadWrite(), is("readWrite"));
 	}
 
 }

--- a/src/test/java/com/arangodb/jackson/dataformat/velocypack/annotations/DocumentFieldEntity.java
+++ b/src/test/java/com/arangodb/jackson/dataformat/velocypack/annotations/DocumentFieldEntity.java
@@ -1,0 +1,112 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2016 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.jackson.dataformat.velocypack.annotations;
+
+import com.arangodb.entity.DocumentField;
+
+import java.util.Objects;
+
+/**
+ * @author Michele Rastelli
+ */
+public class DocumentFieldEntity {
+
+	@DocumentField(DocumentField.Type.ID)
+	private String id;
+
+	@DocumentField(DocumentField.Type.KEY)
+	private String key;
+
+	@DocumentField(DocumentField.Type.REV)
+	private String rev;
+
+	@DocumentField(DocumentField.Type.FROM)
+	private String from;
+
+	@DocumentField(DocumentField.Type.TO)
+	private String to;
+
+	public DocumentFieldEntity() {
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	public String getRev() {
+		return rev;
+	}
+
+	public void setRev(String rev) {
+		this.rev = rev;
+	}
+
+	public String getFrom() {
+		return from;
+	}
+
+	public void setFrom(String from) {
+		this.from = from;
+	}
+
+	public String getTo() {
+		return to;
+	}
+
+	public void setTo(String to) {
+		this.to = to;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		DocumentFieldEntity that = (DocumentFieldEntity) o;
+		return Objects.equals(id, that.id) && Objects.equals(key, that.key) && Objects.equals(rev, that.rev) && Objects
+				.equals(from, that.from) && Objects.equals(to, that.to);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, key, rev, from, to);
+	}
+
+	@Override
+	public String toString() {
+		return "AnnotatedEntity{" + "idField='" + id + '\'' + ", keyField='" + key + '\'' + ", revField='" + rev + '\''
+				+ ", fromField='" + from + '\'' + ", toField='" + to + '\'' + '}';
+	}
+
+}

--- a/src/test/java/com/arangodb/jackson/dataformat/velocypack/annotations/ExposeEntity.java
+++ b/src/test/java/com/arangodb/jackson/dataformat/velocypack/annotations/ExposeEntity.java
@@ -1,0 +1,101 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2016 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.jackson.dataformat.velocypack.annotations;
+
+import com.arangodb.velocypack.annotations.Expose;
+
+import java.util.Objects;
+
+/**
+ * @author Michele Rastelli
+ */
+public class ExposeEntity {
+
+	@Expose()
+	private String readWrite;
+
+	@Expose(deserialize = false)
+	private String readOnly;
+
+	@Expose(serialize = false)
+	private String writeOnly;
+
+	@Expose(serialize = false,
+			deserialize = false)
+	private String ignored;
+
+	public ExposeEntity() {
+	}
+
+	public String getReadWrite() {
+		return readWrite;
+	}
+
+	public void setReadWrite(String readWrite) {
+		this.readWrite = readWrite;
+	}
+
+	public String getReadOnly() {
+		return readOnly;
+	}
+
+	public void setReadOnly(String readOnly) {
+		this.readOnly = readOnly;
+	}
+
+	public String getWriteOnly() {
+		return writeOnly;
+	}
+
+	public void setWriteOnly(String writeOnly) {
+		this.writeOnly = writeOnly;
+	}
+
+	public String getIgnored() {
+		return ignored;
+	}
+
+	public void setIgnored(String ignored) {
+		this.ignored = ignored;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		ExposeEntity that = (ExposeEntity) o;
+		return Objects.equals(readWrite, that.readWrite) && Objects.equals(readOnly, that.readOnly) && Objects
+				.equals(writeOnly, that.writeOnly) && Objects.equals(ignored, that.ignored);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(readWrite, readOnly, writeOnly, ignored);
+	}
+
+	@Override
+	public String toString() {
+		return "ExposeEntity{" + "readWrite='" + readWrite + '\'' + ", readOnly='" + readOnly + '\'' + ", writeOnly='"
+				+ writeOnly + '\'' + ", ignored='" + ignored + '\'' + '}';
+	}
+}

--- a/src/test/java/com/arangodb/jackson/dataformat/velocypack/annotations/SerializedNameEntity.java
+++ b/src/test/java/com/arangodb/jackson/dataformat/velocypack/annotations/SerializedNameEntity.java
@@ -1,0 +1,89 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2016 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.jackson.dataformat.velocypack.annotations;
+
+import com.arangodb.velocypack.annotations.SerializedName;
+
+import java.util.Objects;
+
+/**
+ * @author Michele Rastelli
+ */
+public class SerializedNameEntity {
+
+	final static String SERIALIZED_NAME_A = "aSerializedName";
+	final static String SERIALIZED_NAME_B = "bSerializedName";
+	final static String SERIALIZED_NAME_C = "cSerializedName";
+
+	@SerializedName(SERIALIZED_NAME_A)
+	private String a;
+	private String b;
+	private String c;
+
+	public SerializedNameEntity() {
+	}
+
+	public String getA() {
+		return a;
+	}
+
+	public void setA(String a) {
+		this.a = a;
+	}
+
+	@SerializedName(SERIALIZED_NAME_B)
+	public String getB() {
+		return b;
+	}
+
+	public void setB(String b) {
+		this.b = b;
+	}
+
+	public String getC() {
+		return c;
+	}
+
+	@SerializedName(SERIALIZED_NAME_C)
+	public void setC(String c) {
+		this.c = c;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		SerializedNameEntity that = (SerializedNameEntity) o;
+		return Objects.equals(a, that.a) && Objects.equals(b, that.b) && Objects.equals(c, that.c);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(a, b, c);
+	}
+
+	@Override
+	public String toString() {
+		return "SerializedNameEntity{" + "a='" + a + '\'' + ", b='" + b + '\'' + ", c='" + c + '\'' + '}';
+	}
+}

--- a/src/test/java/com/arangodb/jackson/dataformat/velocypack/annotations/SerializedNameParameterEntity.java
+++ b/src/test/java/com/arangodb/jackson/dataformat/velocypack/annotations/SerializedNameParameterEntity.java
@@ -1,0 +1,83 @@
+/*
+ * DISCLAIMER
+ *
+ * Copyright 2016 ArangoDB GmbH, Cologne, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright holder is ArangoDB GmbH, Cologne, Germany
+ */
+
+package com.arangodb.jackson.dataformat.velocypack.annotations;
+
+import com.arangodb.velocypack.annotations.SerializedName;
+
+import java.util.Objects;
+
+/**
+ * @author Michele Rastelli
+ */
+public class SerializedNameParameterEntity {
+
+	final static String SERIALIZED_NAME_A = "aSerializedName";
+	final static String SERIALIZED_NAME_B = "bSerializedName";
+	final static String SERIALIZED_NAME_C = "cSerializedName";
+
+	private String a;
+	private String b;
+	private String c;
+
+	public SerializedNameParameterEntity(
+			@SerializedName(SERIALIZED_NAME_A)
+					String a,
+			@SerializedName(SERIALIZED_NAME_B)
+					String b,
+			@SerializedName(SERIALIZED_NAME_C)
+					String c) {
+		this.a = a;
+		this.b = b;
+		this.c = c;
+	}
+
+	public String getA() {
+		return a;
+	}
+
+	public String getB() {
+		return b;
+	}
+
+	public String getC() {
+		return c;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		SerializedNameParameterEntity that = (SerializedNameParameterEntity) o;
+		return Objects.equals(a, that.a) && Objects.equals(b, that.b) && Objects.equals(c, that.c);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(a, b, c);
+	}
+
+	@Override
+	public String toString() {
+		return "SerializedNameParameterEntity{" + "a='" + a + '\'' + ", b='" + b + '\'' + ", c='" + c + '\'' + '}';
+	}
+}


### PR DESCRIPTION
Implemented support for ArangoDB driver and Java-Velocypack annotations:
- `@DocumentField`
- `@SerializedName`
- `@Expose`
 
fixes https://github.com/arangodb/jackson-dataformat-velocypack/issues/3